### PR TITLE
Remove hardcoded mongo db path, create datadir relative to script

### DIFF
--- a/start_mongo.sh
+++ b/start_mongo.sh
@@ -1,1 +1,4 @@
-mongod -dbpath ~/Code/Clojure/crypto-news/mongo-data/
+#!/bin/sh
+datadir="$(dirname $0)/mongo-data/"
+mkdir -p "$datadir"
+mongod -dbpath "$datadir"


### PR DESCRIPTION
The start_mongo.sh script currently contains a hardcoded path to ~/Code/... -- this just removes that path and creates mongo's data dir in the project's directory instead.
